### PR TITLE
Improves Doc with sonar_rules_reused.md and passing it to tooling (sh scripts)

### DIFF
--- a/tools/rules_config/README.md
+++ b/tools/rules_config/README.md
@@ -6,7 +6,7 @@ Purpose
 
 1. **Rules Tagging system**
 
-Add one new tag to a list of rules (using SonarQube API).
+Add one new tag to a list of rules from `SONAR_RULES_REUSED.md` (using SonarQube API).
 Why ? because maybe some original SonarQube rules are already ready for being part of this plugin
 
 2. **EcoCode Quality Profile**
@@ -27,7 +27,7 @@ Requirements
   - Sonar token (`SONAR_TOKEN` variable) : put here the new added token previously
   - Sonar URL (`SONAR_URL` variable) : put here your custom Sonar URL ("http://localhost:9000" by default)
   - name of tag to add (`TAG_ECOCONCEPTION` variable) : the name of the new tag to add to a list of rules
-  - rules keys list (string format separated with one comma) (`RULES_KEYS` variable) : specify here the list of all keys of rules that you want to add th new tag
+  - file path to `SONAR_RULES_REUSED.md` (`FILEPATH_SONAR_RULES_REUSED` variable) : filepath in the local folder. Contains all rules.
   - name of profile to add (`PROFILE_ECOCONCEPTION` variable) : the name of the new profile to add for each language
   - language keys list (string format separated with one comma) (`PROFILES_LANGUAGE_KEYS` variable) : specify here the list of all keys language that you want to add the new ecocode quality profile
 
@@ -68,7 +68,7 @@ Algorithm
 
 1. **Tags**
 
-- get rules data (rules list from config file)
+- get rules data (rules list from parsing `SONAR_RULES_REUSED.md`)
 - check if new tag to add (from config file) already exists on systags array or tags array
 - add new tag to all existing tags if necessary
 
@@ -94,3 +94,12 @@ How does it work ?
 - launch `install_tags.sh` to add custom tag to your rules
 - launch `check_tags.sh` again to control your rules and tags
 - launch `install_profile.sh` to create profiles with the new rules from plugins
+
+Contributing ?
+--------------
+
+**You want to add new pre-existing rule from Sonar ?**
+- You have to find the sonar key from **"RULES"** view on Sonarqube
+- adding a new line to `SONAR_RULES_REUSED.md` with this key
+- add references to justify this value
+- Create a Pull Request following #CONTRIBUTING.md

--- a/tools/rules_config/SONAR_RULES_REUSED.md
+++ b/tools/rules_config/SONAR_RULES_REUSED.md
@@ -1,0 +1,5 @@
+| Rules Id | Description | Reference/Validation |
+|--|--|--|
+| css:S4655 | "!important" should not be used on "keyframes" | -- |
+| php:S2014 | "$this" should not be used in a static context | -- |
+| Web:ItemTagNotWithinContainerTagCheck | "\<li>" and "\<dt>" item tags should be in "\<ul>", "\<ol>" or "\<dl>" container tags | -- |

--- a/tools/rules_config/_config.sh
+++ b/tools/rules_config/_config.sh
@@ -25,9 +25,8 @@ SONAR_URL=http://localhost:9000
 TAG_ECOCONCEPTION=test1
 # TAG_ECOCONCEPTION=
 
-# list of rule keys that will be updated with new tag
-RULES_KEYS=css:S4655,php:S2014,Web:ItemTagNotWithinContainerTagCheck
-# RULES_KEYS=
+# filepath to markdown doc containing rule keys that will be updated with new tag
+FILEPATH_SONAR_RULES_REUSED='./SONAR_RULES_REUSED.md'
 
 # name quality profile
 PROFILE_ECOCONCEPTION="EcoCodeProfile"

--- a/tools/rules_config/_core.sh
+++ b/tools/rules_config/_core.sh
@@ -21,6 +21,30 @@ debug() {
   fi
 }
 
+### Read FILEPATH_SONAR_RULES_REUSED file to extract RULES_KEYS
+function read_sonar_rules_reused {
+  debug "Read file ${FILEPATH_SONAR_RULES_REUSED}"
+  linenumber=1
+  interal_field_separator='|'
+  rules_keys=""
+  {
+    #Skip header file markdown
+    read -r
+    read -r
+    while IFS='|' read -ra line; do
+      col=0;
+      for substr in "${line[@]}"; do
+        if [ $col -eq 1 ]; then
+          rules_keys="$rules_keys$(echo $substr | xargs),"
+        fi
+        col=$((col+1))
+      done
+    done
+  } < $FILEPATH_SONAR_RULES_REUSED
+  debug "Extracting rules: ${rules_keys::-1} \n"
+  RULES_KEYS=${rules_keys::-1}
+}
+
 ### build array with all rules
 ### $1 : the variable to set into the computed response (using it by reference)
 declare -a RULES_ARRAY
@@ -126,6 +150,9 @@ function validate_parameters() {
 ###########################################################################################
 #    C O R E     I N I T I A L I Z A T I O N    ( /!\ /!\ /!\ NOT to modify)
 ###########################################################################################
+
+### export rules keys from markdown documentation
+read_sonar_rules_reused
 
 ### transform string list of rules keys (separated by a ,) to an array
 build_rules_array


### PR DESCRIPTION
### Objectives
Gives a better comprehension of rules needed to be tag by "eco-design"
- By listing them with a user friendly view (on Github) with markdown
- Capitalize justifications about rules (with a tab)

Gives a one entry point to adding rules. (Not have to copy/paste new rules... risk to desync)

### Execution
After testing script on my Ubuntu wsl, you wil got this log bash: 
```
XXX@YYYY:/mnt/c/Dev/projets/ecoCode-common-5R/tools/rules_config$ ./install_tag.sh
--- DEBUG --- Read file ./SONAR_RULES_REUSED.md
--- DEBUG --- Extracting rules: css:S4655,php:S2014,Web:ItemTagNotWithinContainerTagCheck

--- DEBUG --- SONAR_TOKEN : zzzzzzzzzzzzzzzzzzzzzzzz
--- DEBUG --- SONAR_URL : http://localhost:9000
--- DEBUG --- RULES_KEYS : css:S4655,php:S2014,Web:ItemTagNotWithinContainerTagCheck
--- DEBUG --- TAG_ECOCONCEPTION : test1

*****  Checking SonarQube connection  *****
--- DEBUG --- SonarQube connection ok : 200

*****  Processing rule css:S4655  *****
Existing sysTags : []
Existing tags : []
  Tag test1 NOT FOUND in tags array nor in systags array : we will add it to rule 'css:S4655'
Execution of command : curl -u zzzzzzzzzzzzzzzzzzzz: -s -o /dev/null --request POST "http://localhost:9000/api/rules/update?key=css:S4655&tags=test1"
CALL to Sonar API to add tag

*****  Processing rule php:S2014  *****
Existing sysTags : []
Existing tags : []
  Tag test1 NOT FOUND in tags array nor in systags array : we will add it to rule 'php:S2014'
Execution of command : curl -u zzzzzzzzzzzzzzzzzzzzz: -s -o /dev/null --request POST "http://localhost:9000/api/rules/update?key=php:S2014&tags=test1"
CALL to Sonar API to add tag

*****  Processing rule Web:ItemTagNotWithinContainerTagCheck  *****
Existing sysTags : []
Existing tags : []
  Tag test1 NOT FOUND in tags array nor in systags array : we will add it to rule 'Web:ItemTagNotWithinContainerTagCheck'
Execution of command : curl -u zzzzzzzzzzzzzzzzzzz: -s -o /dev/null --request POST "http://localhost:9000/api/rules/update?key=Web:ItemTagNotWithinContainerTagCheck&tags=test1"
CALL to Sonar API to add tag

==> 3 rules updated
```

Will need a PR about "ecoconception" key word to switch to "ecodesign" like main repo.
I have also identify the script shell not failed in error if your token is not a **user token**.
