### PR TITLE
Update starter pack Sonarqube plugin section

### DIFF
--- a/doc/starter-pack.md
+++ b/doc/starter-pack.md
@@ -40,12 +40,12 @@ In order to develop a Sonarqube Plugin in Open source for ecocode, two basics mu
 
 #### How a SonarQube plugin works
 
-Code is parsed to be transformed as AST. AST will allow you to access one or more nodes of your code.
-For example, you’ll be able to access of all your `for` loop, to explore content etc.
+Code is parsed to be transformed as an [AST (Abstract Syntax Tree)](https://en.wikipedia.org/wiki/Abstract_syntax_tree). This AST will allow you to access one or more nodes of your code.
+For example, you’ll be able to access of all the `for` loops, to explore content etc.
 
-To better understand AST structure, you can use the [AST Explorer](https://astexplorer.net/).
+To better understand AST structure, you can use the [AST Explorer](https://astexplorer.net/) and select the language of the code you want to explore.
 
-JavaScript plugin works differently because it does not use AST. [More information here](javascript-plugin/README.md)
+The JavaScript Sonar plugin works differently because it doesn't parse the code to transform it into an AST itself, it use the ESLint engine which will do it itself ([More information here](https://github.com/green-code-initiative/ecoCode-javascript/blob/main/CONTRIBUTING.md)). The good part is that it means that all Ecocode JavaScript rules are made available both to Sonar and to [ESLint](https://eslint.org/) through an [Ecocode ESLint plugin](https://www.npmjs.com/package/@ecocode/eslint-plugin).
 
 ### Gitflow
 


### PR DESCRIPTION
The original version says that the JavaScript version doesn't use an AST which is wrong, it uses one provided by ESLint

Also 
- precise that AST stands for "Abstract Syntax Tree" 
- add a link to Wikipedia
- fix the broken link to the JavaScript plugin