### PR TITLE
fix(#46): add jq in requirements documentation and scripts

### DIFF
--- a/doc/starter-pack.md
+++ b/doc/starter-pack.md
@@ -76,6 +76,14 @@ This section is to help you to install and configure your first environment to d
 
 ### Requirements
 
+These tools are necessary :
+- `Docker` : <https://docs.docker.com/get-docker/>
+- `Docker-compose` : <https://docs.docker.com/compose/install/>
+- `Java` JDK (and not only JRE) for Sonarqube plugin Development : <https://www.java.com/fr/download/manual.jsp>
+- `Maven` for Sonarqube plugin Development : <https://maven.apache.org/download.cgi>
+- `Git` : <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>
+- `jq` : <https://jqlang.github.io/jq/download/>. If you need to install `jq`, you can launch `tools/check_requirements/install_jq.bat`
+
 #### Method 1 - Automatic check (default method)
 
 In the current repository, go to `tools/check_requirements` directory.
@@ -92,12 +100,6 @@ PS : if you have some problems with this script, please feel free to create a ne
 
 #### Method 2 - Manual check (if above "method 1" doesn't work)
 
-- `Docker` : <https://docs.docker.com/get-docker/>
-- `Docker-compose` : <https://docs.docker.com/compose/install/>
-- `Java` JDK (and not only JRE) for Sonarqube plugin Development : <https://www.java.com/fr/download/manual.jsp>
-- `Maven` for Sonarqube plugin Development : <https://maven.apache.org/download.cgi>
-- `Git` : <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>
-
 If you want, you can check following file to know what are min and max versions for each tool : <https://github.com/green-code-initiative/ecoCode-common/blob/main/tools/check_requirements/config.txt>
 
 Then launch check commands as follows (and check versions displayed) :
@@ -108,6 +110,7 @@ docker-compose --version
 javap -version
 mvn --version
 git --version
+jq --version
 ```
 
 ### Get source code

--- a/tools/check_requirements/README.md
+++ b/tools/check_requirements/README.md
@@ -32,6 +32,7 @@ For Mac OSX and Linux :
 For Windows :
 
 - `check_requirements.bat` : tool checker for Windows
+- `install_jq.bat` : script to install easily `jq` for Windows with `winget`
 
 Common files:
 
@@ -40,6 +41,7 @@ Common files:
 ## How does it work?
 
 - [OPTIONAL] change the configuration in `config.txt` file
+- [OPTIONAL] launch `install_jq.bat` if you need to install `jq` for Windows
 
 For Mac OSX and Linux :
 

--- a/tools/check_requirements/check_requirements.bat
+++ b/tools/check_requirements/check_requirements.bat
@@ -97,4 +97,12 @@ if errorlevel 1 (
     echo [OK] Git is installed.
 )
 
+:: Check jq
+call jq --version >nul 2>&1
+if errorlevel 1 (
+    echo [FAIL] jq is not installed.
+) else (
+    echo [OK] jq is installed.
+)
+
 endlocal

--- a/tools/check_requirements/check_requirements.sh
+++ b/tools/check_requirements/check_requirements.sh
@@ -31,3 +31,6 @@ check_version_max_maven "$mvn_version" "$MAVEN_VERSION_MAX"
 
 echo -e "***** Git 🚀"
 check_installation "git --version"
+
+echo -e "***** jq 🚀"
+check_installation "jq --version"

--- a/tools/check_requirements/install_jq.bat
+++ b/tools/check_requirements/install_jq.bat
@@ -1,0 +1,4 @@
+@echo off
+
+:: install jq
+call winget install jqlang.jq


### PR DESCRIPTION
- Add jq in starter-pack.md
- Add checks in check_requirements.sh and check_requirements.bat
- Create install_jq.bat for Windows to simplify installation (with the creation of an alias) + documentation
- Specify necessary tools in "requirements" section rather than "manual check" section to improve understanding of requirements.