### PR TITLE
Bootstrap BMad hub structure under .bmad

### DIFF
--- a/.bmad/catalog/dependencies.yaml
+++ b/.bmad/catalog/dependencies.yaml
@@ -56,19 +56,19 @@ repositories:
       - compatibility_matrix_results
       - release_readiness_signal
 
-  creedengo-csharp-sonarqube:
-    consumes:
-      - creedengo-csharp
-      - creedengo-rules-specifications
-    produces:
-      - csharp_plugin_implementation
-      - csharp_plugin_contract_validation
-
 plugins:
   process_dependencies:
     - creedengo-common
     - creedengo-rules-specifications
     - creedengo-integration-test
+  plugin_specific_dependencies:
+    creedengo-csharp-sonarqube:
+      consumes:
+        - creedengo-csharp
+        - creedengo-rules-specifications
+      produces:
+        - csharp_plugin_implementation
+        - csharp_plugin_contract_validation
   target_plugin_repositories:
     - creedengo-csharp-sonarqube
     - creedengo-flutter-mobile

--- a/.bmad/catalog/dependencies.yaml
+++ b/.bmad/catalog/dependencies.yaml
@@ -1,6 +1,15 @@
 version: 1
 updated_at: 2026-06-30
 
+sharing_policy:
+  creedengo-common:
+    purpose: process_only
+    technical_artifacts_allowed: false
+    maven_dependency_expected: false
+  technical_sharing_repositories:
+    rules_and_specs: creedengo-rules-specifications
+    integration_tests: creedengo-integration-test
+
 repositories:
   creedengo-rules-specifications:
     consumes:

--- a/.bmad/catalog/dependencies.yaml
+++ b/.bmad/catalog/dependencies.yaml
@@ -72,7 +72,53 @@ plugins:
     - creedengo-common
     - creedengo-rules-specifications
     - creedengo-integration-test
-  maven_dependencies_verified_from_pom_xml:
+  target_plugin_repositories:
+    - creedengo-csharp-sonarqube
+    - creedengo-flutter-mobile
+    - creedengo-android-java
+    - creedengo-android-kotlin
+    - creedengo-ios
+    - creedengo-dashboard
+    - creedengo-java
+    - creedengo-php
+    - creedengo-python
+    - creedengo-javascript
+    - creedengo-kotlin
+    - creedengo-rust
+    - creedengo-html
+    - creedengo-infra
+  target_maven_dependencies_norm:
+    creedengo-rules-specifications:
+      - creedengo-csharp-sonarqube
+      - creedengo-flutter-mobile
+      - creedengo-android-java
+      - creedengo-android-kotlin
+      - creedengo-ios
+      - creedengo-dashboard
+      - creedengo-java
+      - creedengo-php
+      - creedengo-python
+      - creedengo-javascript
+      - creedengo-kotlin
+      - creedengo-rust
+      - creedengo-html
+      - creedengo-infra
+    creedengo-integration-test:
+      - creedengo-csharp-sonarqube
+      - creedengo-flutter-mobile
+      - creedengo-android-java
+      - creedengo-android-kotlin
+      - creedengo-ios
+      - creedengo-dashboard
+      - creedengo-java
+      - creedengo-php
+      - creedengo-python
+      - creedengo-javascript
+      - creedengo-kotlin
+      - creedengo-rust
+      - creedengo-html
+      - creedengo-infra
+  maven_dependencies_observed_locally_from_pom_xml:
     creedengo-rules-specifications:
       - creedengo-csharp-sonarqube
       - creedengo-ios

--- a/.bmad/catalog/dependencies.yaml
+++ b/.bmad/catalog/dependencies.yaml
@@ -55,8 +55,8 @@ repositories:
       - creedengo-rules-specifications
       - creedengo-common
     produces:
-      - adapter_implementation
-      - adapter_contract_validation
+      - csharp_plugin_implementation
+      - csharp_plugin_contract_validation
 
 plugins:
   process_dependencies:
@@ -65,6 +65,7 @@ plugins:
     - creedengo-integration-test
   maven_dependencies_verified_from_pom_xml:
     creedengo-rules-specifications:
+      - creedengo-csharp-sonarqube
       - creedengo-ios
       - creedengo-java
       - creedengo-php
@@ -83,6 +84,7 @@ plugins:
       - creedengo-dashboard
       - creedengo-rust
     creedengo-integration-test:
+      - creedengo-csharp-sonarqube
       - creedengo-flutter-mobile
       - creedengo-ios
       - creedengo-dashboard
@@ -100,4 +102,3 @@ release_train:
     - creedengo-integration-test
   optional_gatekeepers:
     - creedengo-csharp
-    - creedengo-csharp-sonarqube

--- a/.bmad/catalog/dependencies.yaml
+++ b/.bmad/catalog/dependencies.yaml
@@ -59,10 +59,40 @@ repositories:
       - adapter_contract_validation
 
 plugins:
-  all_plugins_depend_on:
+  process_dependencies:
     - creedengo-common
     - creedengo-rules-specifications
     - creedengo-integration-test
+  maven_dependencies_verified_from_pom_xml:
+    creedengo-rules-specifications:
+      - creedengo-ios
+      - creedengo-java
+      - creedengo-php
+      - creedengo-python
+      - creedengo-javascript
+      - creedengo-kotlin
+      - creedengo-infra
+    creedengo-integration-test:
+      - creedengo-java
+      - creedengo-php
+      - creedengo-python
+      - creedengo-infra
+  repositories_without_matching_pom_dependency:
+    creedengo-rules-specifications:
+      - creedengo-flutter-mobile
+      - creedengo-dashboard
+      - creedengo-rust
+    creedengo-integration-test:
+      - creedengo-flutter-mobile
+      - creedengo-ios
+      - creedengo-dashboard
+      - creedengo-javascript
+      - creedengo-kotlin
+      - creedengo-rust
+  repositories_not_found_locally:
+    - creedengo-android-java
+    - creedengo-android-kotlin
+    - creedengo-html
 
 release_train:
   gatekeepers:

--- a/.bmad/catalog/dependencies.yaml
+++ b/.bmad/catalog/dependencies.yaml
@@ -13,8 +13,6 @@ sharing_policy:
 
 repositories:
   creedengo-rules-specifications:
-    consumes:
-      - creedengo-common
     produces:
       - cross_repo_epics
       - rule_lifecycle_definitions
@@ -38,9 +36,8 @@ repositories:
 
   creedengo-integration-test:
     consumes:
-      - creedengo-common
       - creedengo-rules-specifications
-      - creedengo-csharp
+    required_by:
       - creedengo-csharp-sonarqube
       - creedengo-flutter-mobile
       - creedengo-android-java
@@ -63,7 +60,6 @@ repositories:
     consumes:
       - creedengo-csharp
       - creedengo-rules-specifications
-      - creedengo-common
     produces:
       - csharp_plugin_implementation
       - csharp_plugin_contract_validation

--- a/.bmad/catalog/dependencies.yaml
+++ b/.bmad/catalog/dependencies.yaml
@@ -1,5 +1,6 @@
 version: 1
 updated_at: 2026-06-30
+dependency_model: target_and_observed_state
 
 sharing_policy:
   creedengo-common:
@@ -119,6 +120,7 @@ plugins:
       - creedengo-html
       - creedengo-infra
   maven_dependencies_observed_locally_from_pom_xml:
+    description: "Current state observed locally from available pom.xml files"
     creedengo-rules-specifications:
       - creedengo-csharp-sonarqube
       - creedengo-ios

--- a/.bmad/catalog/dependencies.yaml
+++ b/.bmad/catalog/dependencies.yaml
@@ -1,5 +1,5 @@
 version: 1
-updated_at: 2026-06-30
+updated_at: 2026-07-01
 dependency_model: target_and_observed_state
 
 sharing_policy:
@@ -133,10 +133,14 @@ plugins:
       - creedengo-infra
   repositories_without_matching_pom_dependency:
     creedengo-rules-specifications:
+      - creedengo-android-java
+      - creedengo-html
       - creedengo-flutter-mobile
       - creedengo-dashboard
       - creedengo-rust
     creedengo-integration-test:
+      - creedengo-android-java
+      - creedengo-html
       - creedengo-csharp-sonarqube
       - creedengo-flutter-mobile
       - creedengo-ios
@@ -144,10 +148,21 @@ plugins:
       - creedengo-javascript
       - creedengo-kotlin
       - creedengo-rust
-  repositories_not_found_locally:
-    - creedengo-android-java
+  repositories_without_pom_xml_locally:
     - creedengo-android-kotlin
-    - creedengo-html
+  repositories_observed_with_non_maven_build:
+    creedengo-android-kotlin:
+      build_system: gradle-kotlin-dsl
+      build_files:
+        - build.gradle.kts
+        - settings.gradle.kts
+      observed_references:
+        creedengo-rules-specifications:
+          source: README.md
+          note: "Referenced as shared rules specifications (not observed as Maven dependency)."
+        creedengo-integration-test:
+          source: none
+          note: "No local technical dependency reference detected."
 
 release_train:
   gatekeepers:

--- a/.bmad/catalog/dependencies.yaml
+++ b/.bmad/catalog/dependencies.yaml
@@ -1,0 +1,73 @@
+version: 1
+updated_at: 2026-06-30
+
+repositories:
+  creedengo-rules-specifications:
+    consumes:
+      - creedengo-common
+    produces:
+      - cross_repo_epics
+      - rule_lifecycle_definitions
+    required_by:
+      - creedengo-integration-test
+      - creedengo-csharp
+      - creedengo-csharp-sonarqube
+      - creedengo-flutter-mobile
+      - creedengo-android-java
+      - creedengo-android-kotlin
+      - creedengo-ios
+      - creedengo-dashboard
+      - creedengo-java
+      - creedengo-php
+      - creedengo-python
+      - creedengo-javascript
+      - creedengo-kotlin
+      - creedengo-rust
+      - creedengo-html
+      - creedengo-infra
+
+  creedengo-integration-test:
+    consumes:
+      - creedengo-common
+      - creedengo-rules-specifications
+      - creedengo-csharp
+      - creedengo-csharp-sonarqube
+      - creedengo-flutter-mobile
+      - creedengo-android-java
+      - creedengo-android-kotlin
+      - creedengo-ios
+      - creedengo-dashboard
+      - creedengo-java
+      - creedengo-php
+      - creedengo-python
+      - creedengo-javascript
+      - creedengo-kotlin
+      - creedengo-rust
+      - creedengo-html
+      - creedengo-infra
+    produces:
+      - compatibility_matrix_results
+      - release_readiness_signal
+
+  creedengo-csharp-sonarqube:
+    consumes:
+      - creedengo-csharp
+      - creedengo-rules-specifications
+      - creedengo-common
+    produces:
+      - adapter_implementation
+      - adapter_contract_validation
+
+plugins:
+  all_plugins_depend_on:
+    - creedengo-common
+    - creedengo-rules-specifications
+    - creedengo-integration-test
+
+release_train:
+  gatekeepers:
+    - creedengo-rules-specifications
+    - creedengo-integration-test
+  optional_gatekeepers:
+    - creedengo-csharp
+    - creedengo-csharp-sonarqube

--- a/.bmad/catalog/repositories.yaml
+++ b/.bmad/catalog/repositories.yaml
@@ -1,0 +1,112 @@
+version: 1
+updated_at: 2026-06-30
+hub_repository: creedengo-common
+
+repositories:
+  - id: creedengo-common
+    type: hub
+    role: "BMad templates, workflows and shared process source of truth"
+    owner: "@core-team"
+    default_branch: main
+
+  - id: creedengo-rules-specifications
+    type: governance
+    role: "Rule ideation, lifecycle and cross-repo epic orchestration"
+    owner: "@rules-team"
+    default_branch: main
+
+  - id: creedengo-integration-test
+    type: validation
+    role: "Cross-repository integration and compatibility matrix validation"
+    owner: "@qa-team"
+    default_branch: main
+
+  - id: creedengo-csharp
+    type: core
+    role: "Core contracts and shared behavior for C#-based ecosystem"
+    owner: "@csharp-core-team"
+    default_branch: main
+
+  - id: creedengo-csharp-sonarqube
+    type: adapter
+    role: "SonarQube adapter for creedengo-csharp contracts"
+    owner: "@csharp-adapter-team"
+    default_branch: main
+
+  - id: creedengo-flutter-mobile
+    type: plugin
+    role: "SonarQube plugin for Flutter mobile codebases"
+    owner: "@flutter-team"
+    default_branch: main
+
+  - id: creedengo-android-java
+    type: plugin
+    role: "SonarQube plugin for Android Java"
+    owner: "@android-java-team"
+    default_branch: main
+
+  - id: creedengo-android-kotlin
+    type: plugin
+    role: "SonarQube plugin for Android Kotlin"
+    owner: "@android-kotlin-team"
+    default_branch: main
+
+  - id: creedengo-ios
+    type: plugin
+    role: "SonarQube plugin for iOS projects"
+    owner: "@ios-team"
+    default_branch: main
+
+  - id: creedengo-dashboard
+    type: plugin
+    role: "Dashboard and reporting surfaces for Creedengo rules"
+    owner: "@dashboard-team"
+    default_branch: main
+
+  - id: creedengo-java
+    type: plugin
+    role: "SonarQube plugin for Java"
+    owner: "@java-team"
+    default_branch: main
+
+  - id: creedengo-php
+    type: plugin
+    role: "SonarQube plugin for PHP"
+    owner: "@php-team"
+    default_branch: main
+
+  - id: creedengo-python
+    type: plugin
+    role: "SonarQube plugin for Python"
+    owner: "@python-team"
+    default_branch: main
+
+  - id: creedengo-javascript
+    type: plugin
+    role: "SonarQube plugin for JavaScript"
+    owner: "@javascript-team"
+    default_branch: main
+
+  - id: creedengo-kotlin
+    type: plugin
+    role: "SonarQube plugin for Kotlin"
+    owner: "@kotlin-team"
+    default_branch: main
+
+  - id: creedengo-rust
+    type: plugin
+    role: "SonarQube plugin for Rust"
+    owner: "@rust-team"
+    default_branch: main
+
+  - id: creedengo-html
+    type: plugin
+    role: "SonarQube plugin for HTML"
+    owner: "@html-team"
+    default_branch: main
+
+  - id: creedengo-infra
+    type: plugin
+    role: "Infrastructure and delivery repository for platform operations"
+    owner: "@infra-team"
+    default_branch: main

--- a/.bmad/catalog/repositories.yaml
+++ b/.bmad/catalog/repositories.yaml
@@ -5,7 +5,7 @@ hub_repository: creedengo-common
 repositories:
   - id: creedengo-common
     type: hub
-    role: "BMad templates, workflows and shared process source of truth"
+    role: "BMad templates/workflows source of truth (process only, no shared runtime libs)"
     owner: "@core-team"
     default_branch: main
 

--- a/.bmad/catalog/repositories.yaml
+++ b/.bmad/catalog/repositories.yaml
@@ -23,14 +23,14 @@ repositories:
 
   - id: creedengo-csharp
     type: core
-    role: "Core contracts and shared behavior for C#-based ecosystem"
+    role: "Core C# module providing shared linter foundation and contracts"
     owner: "@csharp-core-team"
     default_branch: main
 
   - id: creedengo-csharp-sonarqube
-    type: adapter
-    role: "SonarQube adapter for creedengo-csharp contracts"
-    owner: "@csharp-adapter-team"
+    type: plugin
+    role: "SonarQube plugin for C# based on creedengo-csharp core linter"
+    owner: "@csharp-team"
     default_branch: main
 
   - id: creedengo-flutter-mobile

--- a/.bmad/scripts/bootstrap-repo.sh
+++ b/.bmad/scripts/bootstrap-repo.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Bootstrap utility for Creedengo repositories.
+# Purpose:
+# - create a minimal `.bmad/` scaffold in a target repository
+# - initialize a default `repo-context.yaml`
+# - copy the shared DoD checklist from this hub repository
+# The script is idempotent for generated files (it does not overwrite existing ones).
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BMAD_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
@@ -25,6 +32,8 @@ if [[ $# -lt 1 || $# -gt 2 ]]; then
   exit 1
 fi
 
+# 1) Resolve and validate target repository path.
+echo "[1/5] Resolving and validating target repository path..."
 TARGET_REPO_PATH="$1"
 if [[ ! -d "${TARGET_REPO_PATH}" ]]; then
   echo "Error: target repository path does not exist: ${TARGET_REPO_PATH}" >&2
@@ -34,9 +43,16 @@ fi
 TARGET_REPO_PATH="$(cd "${TARGET_REPO_PATH}" && pwd)"
 REPOSITORY_ID="${2:-$(basename "${TARGET_REPO_PATH}")}"
 BMAD_DIR="${TARGET_REPO_PATH}/.bmad"
+echo "      Target: ${TARGET_REPO_PATH}"
+echo "      Repository ID: ${REPOSITORY_ID}"
+echo "      BMad dir: ${BMAD_DIR}"
 
+# 2) Create required BMad directories.
+echo "[2/5] Creating required BMad directories..."
 mkdir -p "${BMAD_DIR}/backlog/stories" "${BMAD_DIR}/quality"
 
+# 3) Generate default repo context only if it does not already exist.
+echo "[3/5] Ensuring repo-context.yaml exists..."
 REPO_CONTEXT_FILE="${BMAD_DIR}/repo-context.yaml"
 if [[ ! -f "${REPO_CONTEXT_FILE}" ]]; then
   cat > "${REPO_CONTEXT_FILE}" <<EOF
@@ -56,14 +72,25 @@ dependencies:
 links:
   bmad_hub_templates: "../creedengo-common/.bmad/templates"
 EOF
+  echo "      Created: ${REPO_CONTEXT_FILE}"
+else
+  echo "      Skipped (already exists): ${REPO_CONTEXT_FILE}"
 fi
 
+# 4) Copy shared DoD template once, keeping local customizations safe.
+echo "[4/5] Ensuring DoD checklist exists..."
 DOD_TEMPLATE="${BMAD_ROOT}/templates/dod-checklist.md"
 DOD_FILE="${BMAD_DIR}/quality/dod-checklist.md"
 if [[ ! -f "${DOD_FILE}" ]]; then
   cp "${DOD_TEMPLATE}" "${DOD_FILE}"
+  echo "      Copied template to: ${DOD_FILE}"
+else
+  echo "      Skipped (already exists): ${DOD_FILE}"
 fi
 
+# 5) Keep backlog/stories tracked in git even when empty.
+echo "[5/5] Ensuring stories/.gitkeep exists..."
 touch "${BMAD_DIR}/backlog/stories/.gitkeep"
+echo "      Ensured: ${BMAD_DIR}/backlog/stories/.gitkeep"
 
 echo "BMad scaffold initialized for ${REPOSITORY_ID} at ${BMAD_DIR}"

--- a/.bmad/scripts/bootstrap-repo.sh
+++ b/.bmad/scripts/bootstrap-repo.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BMAD_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bootstrap-repo.sh <target-repo-path> [repository-id]
+
+Arguments:
+  target-repo-path  Path to the repository to initialize
+  repository-id     Optional repository identifier (defaults to folder name)
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage
+  exit 1
+fi
+
+TARGET_REPO_PATH="$1"
+if [[ ! -d "${TARGET_REPO_PATH}" ]]; then
+  echo "Error: target repository path does not exist: ${TARGET_REPO_PATH}" >&2
+  exit 1
+fi
+
+TARGET_REPO_PATH="$(cd "${TARGET_REPO_PATH}" && pwd)"
+REPOSITORY_ID="${2:-$(basename "${TARGET_REPO_PATH}")}"
+BMAD_DIR="${TARGET_REPO_PATH}/.bmad"
+
+mkdir -p "${BMAD_DIR}/backlog/stories" "${BMAD_DIR}/quality"
+
+REPO_CONTEXT_FILE="${BMAD_DIR}/repo-context.yaml"
+if [[ ! -f "${REPO_CONTEXT_FILE}" ]]; then
+  cat > "${REPO_CONTEXT_FILE}" <<EOF
+version: 1
+repository:
+  id: ${REPOSITORY_ID}
+  role: "Describe the repository role"
+  owner: "@team"
+  maintainers:
+    - "@maintainer"
+dependencies:
+  upstream:
+    - creedengo-common
+    - creedengo-rules-specifications
+  validation:
+    - creedengo-integration-test
+links:
+  bmad_hub_templates: "../creedengo-common/.bmad/templates"
+EOF
+fi
+
+DOD_TEMPLATE="${BMAD_ROOT}/templates/dod-checklist.md"
+DOD_FILE="${BMAD_DIR}/quality/dod-checklist.md"
+if [[ ! -f "${DOD_FILE}" ]]; then
+  cp "${DOD_TEMPLATE}" "${DOD_FILE}"
+fi
+
+touch "${BMAD_DIR}/backlog/stories/.gitkeep"
+
+echo "BMad scaffold initialized for ${REPOSITORY_ID} at ${BMAD_DIR}"

--- a/.bmad/scripts/bootstrap-repo.sh
+++ b/.bmad/scripts/bootstrap-repo.sh
@@ -121,6 +121,10 @@ echo "[4/5] Ensuring DoD checklist exists..."
 DOD_TEMPLATE="${BMAD_ROOT}/templates/dod-checklist.md"
 DOD_FILE="${BMAD_DIR}/quality/dod-checklist.md"
 if [[ ! -f "${DOD_FILE}" ]]; then
+  if [[ ! -f "${DOD_TEMPLATE}" ]]; then
+    echo "Error: DoD template not found: ${DOD_TEMPLATE}" >&2
+    exit 1
+  fi
   cp "${DOD_TEMPLATE}" "${DOD_FILE}"
   echo "      Copied template to: ${DOD_FILE}"
 else

--- a/.bmad/scripts/bootstrap-repo.sh
+++ b/.bmad/scripts/bootstrap-repo.sh
@@ -14,7 +14,12 @@ BMAD_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 usage() {
   cat <<'EOF'
 Usage:
-  bootstrap-repo.sh <target-repo-path> [repository-id]
+  bootstrap-repo.sh [options] <target-repo-path> [repository-id]
+
+Options:
+  --hub-templates-path <path>  Value written to links.bmad_hub_templates in repo-context.yaml
+                               (default: ../creedengo-common/.bmad/templates)
+  -h, --help                   Show this help message
 
 Arguments:
   target-repo-path  Path to the repository to initialize (absolute or relative)
@@ -22,30 +27,64 @@ Arguments:
 EOF
 }
 
-if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
-  usage
-  exit 0
-fi
+DEFAULT_HUB_TEMPLATES_PATH="../creedengo-common/.bmad/templates"
+HUB_TEMPLATES_PATH="${DEFAULT_HUB_TEMPLATES_PATH}"
+TARGET_REPO_PATH=""
+REPOSITORY_ID=""
 
-if [[ $# -lt 1 || $# -gt 2 ]]; then
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --hub-templates-path)
+      if [[ -z "${2:-}" ]]; then
+        echo "Error: --hub-templates-path requires a value." >&2
+        exit 1
+      fi
+      HUB_TEMPLATES_PATH="$2"
+      shift 2
+      ;;
+    -*)
+      echo "Error: unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      if [[ -z "${TARGET_REPO_PATH}" ]]; then
+        TARGET_REPO_PATH="$1"
+      elif [[ -z "${REPOSITORY_ID}" ]]; then
+        REPOSITORY_ID="$1"
+      else
+        echo "Error: too many arguments." >&2
+        usage
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "${TARGET_REPO_PATH}" ]]; then
   usage
   exit 1
 fi
 
 # 1) Resolve and validate target repository path.
 echo "[1/5] Resolving and validating target repository path..."
-TARGET_REPO_PATH="$1"
 if [[ ! -d "${TARGET_REPO_PATH}" ]]; then
   echo "Error: target repository path does not exist: ${TARGET_REPO_PATH}" >&2
   exit 1
 fi
 
 TARGET_REPO_PATH="$(cd "${TARGET_REPO_PATH}" && pwd)"
-REPOSITORY_ID="${2:-$(basename "${TARGET_REPO_PATH}")}"
+REPOSITORY_ID="${REPOSITORY_ID:-$(basename "${TARGET_REPO_PATH}")}"
 BMAD_DIR="${TARGET_REPO_PATH}/.bmad"
 echo "      Target: ${TARGET_REPO_PATH}"
 echo "      Repository ID: ${REPOSITORY_ID}"
 echo "      BMad dir: ${BMAD_DIR}"
+echo "      Hub templates path (repo-context): ${HUB_TEMPLATES_PATH}"
 
 # 2) Create required BMad directories.
 echo "[2/5] Creating required BMad directories..."
@@ -70,7 +109,7 @@ dependencies:
   validation:
     - creedengo-integration-test
 links:
-  bmad_hub_templates: "../creedengo-common/.bmad/templates"
+  bmad_hub_templates: "${HUB_TEMPLATES_PATH}"
 EOF
   echo "      Created: ${REPO_CONTEXT_FILE}"
 else

--- a/.bmad/scripts/bootstrap-repo.sh
+++ b/.bmad/scripts/bootstrap-repo.sh
@@ -97,7 +97,7 @@ if [[ ! -f "${REPO_CONTEXT_FILE}" ]]; then
   cat > "${REPO_CONTEXT_FILE}" <<EOF
 version: 1
 repository:
-  id: ${REPOSITORY_ID}
+  id: "${REPOSITORY_ID}"
   role: "Describe the repository role"
   owner: "@team"
   maintainers:

--- a/.bmad/scripts/bootstrap-repo.sh
+++ b/.bmad/scripts/bootstrap-repo.sh
@@ -17,7 +17,7 @@ Usage:
   bootstrap-repo.sh <target-repo-path> [repository-id]
 
 Arguments:
-  target-repo-path  Path to the repository to initialize
+  target-repo-path  Path to the repository to initialize (absolute or relative)
   repository-id     Optional repository identifier (defaults to folder name)
 EOF
 }

--- a/.bmad/templates/dod-checklist.md
+++ b/.bmad/templates/dod-checklist.md
@@ -1,0 +1,23 @@
+# Definition of Done checklist
+
+Use this checklist in each repository (`.bmad/quality/dod-checklist.md`) and adapt only when needed locally.
+
+## Functional
+- [ ] Story acceptance criteria are met.
+- [ ] Regressions are assessed on impacted rules.
+- [ ] Rule IDs and labels follow naming convention.
+
+## Quality and tests
+- [ ] Unit tests added or updated.
+- [ ] Integration scenarios are updated when required.
+- [ ] Required quality gates are green (lint/test/build).
+
+## Cross-repo
+- [ ] Parent epic and linked stories are synchronized.
+- [ ] Dependency updates are reflected in `dependencies.yaml` when applicable.
+- [ ] Validation evidence is attached in story/PR.
+
+## Documentation and rollout
+- [ ] User/developer documentation updated where applicable.
+- [ ] Release train notes updated.
+- [ ] Owners/maintainers review obtained.

--- a/.bmad/templates/epic.md
+++ b/.bmad/templates/epic.md
@@ -1,0 +1,45 @@
+# Epic {{EPIC_ID}} - {{TITLE}}
+
+## Context
+- Rule ID: {{RULE_ID}}
+- Source: `creedengo-rules-specifications`
+- Owner: {{OWNER}}
+- Status: Draft | In Progress | Done
+
+## Problem statement
+{{PROBLEM_STATEMENT}}
+
+## Scope
+### In
+- {{IN_SCOPE_ITEM_1}}
+- {{IN_SCOPE_ITEM_2}}
+
+### Out
+- {{OUT_OF_SCOPE_ITEM_1}}
+
+## Impacted repositories
+- [ ] creedengo-rules-specifications
+- [ ] creedengo-integration-test
+- [ ] creedengo-csharp
+- [ ] creedengo-csharp-sonarqube
+- [ ] creedengo-java
+- [ ] creedengo-python
+- [ ] creedengo-php
+
+## Cross-repo stories
+- [ ] {{STORY_ID_1}} (`{{REPO_1}}`)
+- [ ] {{STORY_ID_2}} (`{{REPO_2}}`)
+
+## Acceptance criteria
+- [ ] Rule behavior is defined and reviewed.
+- [ ] Stories are created in all impacted repositories.
+- [ ] Integration matrix scenarios are implemented and green.
+- [ ] Release train notes are prepared.
+
+## Risks and mitigations
+- Risk: {{RISK_1}}
+  - Mitigation: {{MITIGATION_1}}
+
+## References
+- Rule spec: {{RULE_SPEC_LINK}}
+- Integration matrix run: {{MATRIX_LINK}}

--- a/.bmad/templates/epic.md
+++ b/.bmad/templates/epic.md
@@ -18,13 +18,12 @@
 - {{OUT_OF_SCOPE_ITEM_1}}
 
 ## Impacted repositories
+Use this checklist as an example only (non-exhaustive). Adapt it to the epic scope and confirm impacted repositories against `.bmad/catalog/dependencies.yaml`.
+
+Example:
 - [ ] creedengo-rules-specifications
 - [ ] creedengo-integration-test
-- [ ] creedengo-csharp
 - [ ] creedengo-csharp-sonarqube
-- [ ] creedengo-java
-- [ ] creedengo-python
-- [ ] creedengo-php
 
 ## Cross-repo stories
 - [ ] {{STORY_ID_1}} (`{{REPO_1}}`)

--- a/.bmad/templates/release-train.md
+++ b/.bmad/templates/release-train.md
@@ -1,0 +1,33 @@
+# Release train {{TRAIN_ID}}
+
+## Scope
+- Rule set: {{RULE_SET}}
+- Window: {{START_DATE}} -> {{END_DATE}}
+- Coordinator: {{COORDINATOR}}
+
+## Included epics
+- [ ] {{EPIC_ID_1}}
+- [ ] {{EPIC_ID_2}}
+
+## Repository readiness
+| Repository | Story/PR | Status | Notes |
+| --- | --- | --- | --- |
+| creedengo-rules-specifications | {{LINK}} | TODO | |
+| creedengo-integration-test | {{LINK}} | TODO | |
+| creedengo-java | {{LINK}} | TODO | |
+| creedengo-python | {{LINK}} | TODO | |
+| creedengo-php | {{LINK}} | TODO | |
+
+## Quality gates
+- [ ] CI green on all included repositories.
+- [ ] Compatibility matrix validated in `creedengo-integration-test`.
+- [ ] Blocking defects triaged and resolved.
+
+## Go/No-Go
+- Decision: Go | No-Go
+- Decision date: {{DATE}}
+- Approvers: {{APPROVERS}}
+
+## Post-release follow-up
+- [ ] Metrics capture completed.
+- [ ] Retrospective planned.

--- a/.bmad/templates/story.md
+++ b/.bmad/templates/story.md
@@ -1,0 +1,33 @@
+# Story {{STORY_ID}} - {{TITLE}}
+
+## Repository
+`{{REPOSITORY_ID}}`
+
+## Parent epic
+`{{EPIC_ID}}`
+
+## Goal
+{{GOAL}}
+
+## Description
+{{DESCRIPTION}}
+
+## Tasks
+- [ ] Implementation
+- [ ] Unit tests
+- [ ] Documentation updates
+- [ ] Integration-test evidence attached
+
+## Acceptance criteria
+- [ ] Behavior matches epic criteria.
+- [ ] Local DoD checklist is complete.
+- [ ] CI is green for this repository.
+
+## Dependencies
+- Depends on: {{DEPENDENCY_1}}
+- Blocks: {{BLOCKER_1}}
+
+## Validation evidence
+- PR: {{PR_LINK}}
+- CI run: {{CI_LINK}}
+- Integration matrix run: {{INTEGRATION_LINK}}

--- a/.bmad/workflows/cross-repo-release-flow.md
+++ b/.bmad/workflows/cross-repo-release-flow.md
@@ -1,0 +1,25 @@
+# Workflow - Cross-repo release flow
+
+## Goal
+Coordinate a multi-repository release train with explicit gates and ownership.
+
+## Entry criteria
+- Target epics are in progress with linked stories.
+- Impacted repositories are identified in epic scope.
+
+## Steps
+1. Create release train document from `.bmad/templates/release-train.md`.
+2. Freeze scope for the train.
+3. Collect repository readiness status:
+   - implementation merged
+   - CI quality gates green
+   - documentation updated
+4. Run compatibility matrix validation in `creedengo-integration-test`.
+5. Resolve blockers and rerun validations as needed.
+6. Hold Go/No-Go review with maintainers.
+7. Announce release and archive train notes.
+
+## Exit criteria
+- All mandatory quality gates are green.
+- Compatibility matrix is green for included plugins.
+- Epic statuses are updated and traceable.

--- a/.bmad/workflows/new-rule-flow.md
+++ b/.bmad/workflows/new-rule-flow.md
@@ -1,0 +1,23 @@
+# Workflow - New rule flow
+
+## Goal
+Ensure one new rule is tracked as one cross-repository epic, then implemented through repository-specific stories.
+
+## Steps
+1. Create the rule proposal in `creedengo-rules-specifications`.
+2. Validate Definition of Ready:
+   - rule ID
+   - explicit acceptance criteria
+   - positive/negative examples
+   - impacted repositories list
+3. Create one epic using `.bmad/templates/epic.md`.
+4. Create one story per impacted repository using `.bmad/templates/story.md`.
+5. Implement each story in its target repository.
+6. Update integration scenarios and matrix in `creedengo-integration-test`.
+7. Merge stories/PRs when all local DoD checks are complete.
+8. Close epic only when integration matrix is green and evidence is attached.
+
+## Mandatory links
+- Epic -> all child stories
+- Story -> parent epic + PR
+- Integration matrix run -> epic + release train

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .*
 !.github
 !.gitignore
+!.bmad
+!.bmad/**

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This repository is the shared source of truth for:
 
 The `.bmad/` directory is the bootstrap and process hub for the Creedengo organization.
 
+BMAD (Build More Architect Dreams) is an AI-assisted agile framework: it structures work with reusable artifacts (epics, stories, DoD, workflows) to coordinate delivery across repositories.
+Official documentation: https://github.com/bmad-code-org/BMAD-METHOD
+
 `creedengo-common` is process-only in this model: it does not provide shared runtime libraries or direct Maven dependencies for other repositories.
 Technical sharing stays in:
 - `creedengo-rules-specifications` (rules/spec artifacts)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,33 @@
-# Common doc / tools
+# creedengo-common
 
-This repository contains common parts as follows:
+This repository is the shared source of truth for:
 
-- documentation : please read MarkDown files (`*.md`) in `doc` directory
-- tools : if needed, please read `README.md` files on each tool of `tool` directory
+- common documentation (`doc/`)
+- shared utility scripts (`tools/`)
+- BMad templates, catalogs and workflows (`.bmad/`)
+
+## BMad hub
+
+The `.bmad/` directory is the bootstrap and process hub for the Creedengo organization.
+
+### Structure
+
+- `.bmad/catalog/repositories.yaml`: repository inventory and ownership
+- `.bmad/catalog/dependencies.yaml`: cross-repository dependency map
+- `.bmad/templates/`: epic/story/DoD/release-train templates
+- `.bmad/workflows/`: operational flows for new rules and release trains
+- `.bmad/scripts/bootstrap-repo.sh`: scaffold initializer for `.bmad/` in other repositories
+
+### Bootstrap another repository
+
+From this repository root:
+
+```bash
+./.bmad/scripts/bootstrap-repo.sh ../creedengo-java
+```
+
+Optional repository id:
+
+```bash
+./.bmad/scripts/bootstrap-repo.sh ../creedengo-java creedengo-java
+```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Target future norm for SonarQube plugin repositories: all plugins should depend 
 Current real state is also tracked in `.bmad/catalog/dependencies.yaml` under:
 - `plugins.maven_dependencies_observed_locally_from_pom_xml`
 - `plugins.repositories_without_matching_pom_dependency`
-- `plugins.repositories_not_found_locally`
+- `plugins.repositories_without_pom_xml_locally`
+- `plugins.repositories_observed_with_non_maven_build` (e.g. `creedengo-android-kotlin`)
 
 ### Structure
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ This repository is the shared source of truth for:
 
 The `.bmad/` directory is the bootstrap and process hub for the Creedengo organization.
 
+`creedengo-common` is process-only in this model: it does not provide shared runtime libraries or direct Maven dependencies for other repositories.
+Technical sharing stays in:
+- `creedengo-rules-specifications` (rules/spec artifacts)
+- `creedengo-integration-test` (integration test artifacts)
+
 ### Structure
 
 - `.bmad/catalog/repositories.yaml`: repository inventory and ownership

--- a/README.md
+++ b/README.md
@@ -46,3 +46,9 @@ Optional repository id:
 ```bash
 ./.bmad/scripts/bootstrap-repo.sh ../creedengo-java creedengo-java
 ```
+
+Optional hub templates path written in `.bmad/repo-context.yaml`:
+
+```bash
+./.bmad/scripts/bootstrap-repo.sh --hub-templates-path ../my-bmad-hub/.bmad/templates ../creedengo-java
+```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Technical sharing stays in:
 - `creedengo-integration-test` (integration test artifacts)
 
 Target future norm for SonarQube plugin repositories: all plugins should depend on both `creedengo-rules-specifications` and `creedengo-integration-test`.
+Current real state is also tracked in `.bmad/catalog/dependencies.yaml` under:
+- `plugins.maven_dependencies_observed_locally_from_pom_xml`
+- `plugins.repositories_without_matching_pom_dependency`
+- `plugins.repositories_not_found_locally`
 
 ### Structure
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Technical sharing stays in:
 - `creedengo-rules-specifications` (rules/spec artifacts)
 - `creedengo-integration-test` (integration test artifacts)
 
+Target future norm for SonarQube plugin repositories: all plugins should depend on both `creedengo-rules-specifications` and `creedengo-integration-test`.
+
 ### Structure
 
 - `.bmad/catalog/repositories.yaml`: repository inventory and ownership


### PR DESCRIPTION
## Summary
Bootstrap BMad structure in `creedengo-common` with homogeneous `.bmad/` layout.

## Changes
- add `.bmad/catalog/{repositories.yaml,dependencies.yaml}`
- add `.bmad/templates/{epic.md,story.md,dod-checklist.md,release-train.md}`
- add `.bmad/workflows/{new-rule-flow.md,cross-repo-release-flow.md}`
- add `.bmad/scripts/bootstrap-repo.sh`
- update `README.md` with hub usage and bootstrap instructions
- update `.gitignore` to track `.bmad/**`

## Validation
- `bash -n .bmad/scripts/bootstrap-repo.sh`
- bootstrap smoke test on temp repo (`.bmad` scaffold created)

## Notes
- keeps unrelated local file untouched: `doc/ZZZ_github_repo.md`